### PR TITLE
Remove broken stock-logic-infographic placeholder

### DIFF
--- a/content/en/applets/inventory-workflow/stock-reservation-applet.md
+++ b/content/en/applets/inventory-workflow/stock-reservation-applet.md
@@ -69,8 +69,6 @@ Traditional inventory management relies on physical counts. Common issues includ
 
 {{< figure src="/images/stock-reservation-applet/stock-reservation-overview-infographic.png" alt="Stock Reservation Applet Overview Infographic" caption="At a Glance: The Challenges, Solutions, and Beneficiaries of the Stock Reservation Applet." >}}
 
-{{< figure src="/images/stock-reservation-applet/stock-logic-infographic.png" alt="BigLedger Stock Calculation Logic: Physical (On-Hand) - Reserved = Available (To Sell). Available + Incoming (PO) = Potential Availability." caption="The Golden Equation: Understanding the difference between what's in your bin and what's free to be sold." >}}
-
 ## Key Concepts
 
 ### Understanding the Reservation Framework


### PR DESCRIPTION
## Summary
- Removed the broken `stock-logic-infographic.png` figure reference that was displaying a "Screenshot Coming Soon" placeholder on the wiki

Follow-up to PR #307.

🤖 Generated with [Claude Code](https://claude.com/claude-code)